### PR TITLE
[OS-20]: Add missing serializer relationships

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ colorama==0.4.4
 coverage==5.5
 Django==3.2.5
 djangorestframework==3.12.4
-djangorestframework-recursive==0.1.2
 factory-boy==3.2.0
 Faker==8.10.1
 importlib-metadata==4.6.1

--- a/shop/serializers/__init__.py
+++ b/shop/serializers/__init__.py
@@ -1,0 +1,11 @@
+from rest_framework import serializers
+
+
+class DynamicFieldsModelSerializer(serializers.ModelSerializer):
+    def __init__(self, *args, **kwargs):
+        fields_to_remove = kwargs.pop('fields_to_remove', None)
+        super().__init__(*args, **kwargs)
+
+        if fields_to_remove is not None:
+            for field_name in fields_to_remove:
+                self.fields.pop(field_name)

--- a/shop/serializers/address.py
+++ b/shop/serializers/address.py
@@ -4,9 +4,16 @@ from shop.models import Address
 
 
 class AddressOutputSerializer(serializers.ModelSerializer):
+    orders = serializers.SerializerMethodField()
+
     class Meta:
         model = Address
-        fields = ('user', 'country', 'region', 'city', 'street', 'house_number', 'flat_number', 'postal_code')
+        fields = ('user', 'country', 'region', 'city', 'street', 'house_number', 'flat_number', 'postal_code', 'orders')
+
+    @staticmethod
+    def get_orders(obj):
+        from shop.serializers.order import OrderOutputSerializer
+        return OrderOutputSerializer(obj.orders, many=True, fields_to_remove=['address']).data
 
 
 class AddressInputSerializer(serializers.ModelSerializer):

--- a/shop/serializers/category.py
+++ b/shop/serializers/category.py
@@ -1,17 +1,33 @@
 from rest_framework import serializers
-from rest_framework_recursive.fields import RecursiveField
 
 from shop.models import Category
-from shop.serializers.product import ProductOutputSerializerForCategory
+from shop.serializers import DynamicFieldsModelSerializer
+from shop.serializers.product import ProductOutputSerializer
 
 
-class CategoryOutputSerializer(serializers.ModelSerializer):
-    products = ProductOutputSerializerForCategory(many=True)
-    child_categories = RecursiveField(allow_null=True, many=True)
+class CategoryOutputSerializer(DynamicFieldsModelSerializer):
+    products = ProductOutputSerializer(many=True, fields_to_remove=['category'])
+    child_categories = serializers.SerializerMethodField()
+    parent_category = serializers.SerializerMethodField()
 
     class Meta:
         model = Category
         fields = ('name', 'products', 'parent_category', 'child_categories')
+
+    @staticmethod
+    def get_parent_category(obj):
+        if obj.parent_category:
+            return CategoryOutputSerializer(obj.parent_category).data
+        else:
+            return None
+
+    @staticmethod
+    def get_child_categories(obj):
+        if obj.child_categories:
+            return CategoryOutputSerializer(obj.child_categories, many=True,
+                                            fields_to_remove=['parent_category']).data
+        else:
+            return None
 
 
 class CategoryInputSerializer(serializers.ModelSerializer):

--- a/shop/serializers/feedback.py
+++ b/shop/serializers/feedback.py
@@ -1,26 +1,22 @@
 from rest_framework import serializers
 
 from shop.models import Feedback
-from shop.serializers.image import ImageDetailSerializer
-from shop.serializers.product import ProductOutputSerializer
+from shop.serializers import DynamicFieldsModelSerializer
+from shop.serializers.image import ImageOutputSerializer
 
 
-class FeedbackListSerializer(serializers.ModelSerializer):
-    product = ProductOutputSerializer()
-    images = ImageDetailSerializer(many=True)
-
-    class Meta:
-        model = Feedback
-        fields = ('author', 'product', 'title', 'content', 'images')
-
-
-class FeedbackDetailSerializer(serializers.ModelSerializer):
-    product = ProductOutputSerializer()
-    images = ImageDetailSerializer(many=True)
+class FeedbackOutputSerializer(DynamicFieldsModelSerializer):
+    product = serializers.SerializerMethodField()
+    images = ImageOutputSerializer(many=True)
 
     class Meta:
         model = Feedback
         fields = ('author', 'product', 'title', 'content', 'images')
+
+    @staticmethod
+    def get_product(obj):
+        from shop.serializers.product import ProductOutputSerializer
+        return ProductOutputSerializer(obj.product).data
 
 
 class FeedbackInputSerializer(serializers.ModelSerializer):

--- a/shop/serializers/image.py
+++ b/shop/serializers/image.py
@@ -1,15 +1,10 @@
 from rest_framework import serializers
 
 from shop.models import Image
+from shop.serializers import DynamicFieldsModelSerializer
 
 
-class ImageListSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Image
-        fields = ('image', 'tip', 'content_type', 'object_id')
-
-
-class ImageDetailSerializer(serializers.ModelSerializer):
+class ImageOutputSerializer(DynamicFieldsModelSerializer):
     class Meta:
         model = Image
         fields = ('image', 'tip', 'content_type', 'object_id')

--- a/shop/serializers/order.py
+++ b/shop/serializers/order.py
@@ -1,12 +1,22 @@
 from rest_framework import serializers
 
 from shop.models import Order
+from shop.serializers import DynamicFieldsModelSerializer
+from shop.serializers.address import AddressOutputSerializer
 
 
-class OrderOutputSerializer(serializers.ModelSerializer):
+class OrderOutputSerializer(DynamicFieldsModelSerializer):
+    address = AddressOutputSerializer()
+    order_items = serializers.SerializerMethodField()
+
     class Meta:
         model = Order
-        fields = ('user', 'address', 'is_paid')
+        fields = ('user', 'address', 'is_paid', 'order_items')
+
+    @staticmethod
+    def get_order_items(obj):
+        from shop.serializers.order_item import OrderItemOutputSerializer
+        return OrderItemOutputSerializer(obj.order_items, many=True, fields_to_remove=['order']).data
 
 
 class OrderInputSerializer(serializers.ModelSerializer):

--- a/shop/serializers/order_item.py
+++ b/shop/serializers/order_item.py
@@ -1,11 +1,12 @@
 from rest_framework import serializers
 
 from shop.models import OrderItem
+from shop.serializers import DynamicFieldsModelSerializer
 from shop.serializers.order import OrderOutputSerializer
 from shop.serializers.product import ProductOutputSerializer
 
 
-class OrderItemOutputSerializer(serializers.ModelSerializer):
+class OrderItemOutputSerializer(DynamicFieldsModelSerializer):
     product = ProductOutputSerializer()
     order = OrderOutputSerializer()
 

--- a/shop/serializers/product.py
+++ b/shop/serializers/product.py
@@ -1,24 +1,24 @@
 from rest_framework import serializers
 
 from shop.models import Product
-from shop.serializers.product_material import ProductMaterialOutputSerializerForProduct
+from shop.serializers import DynamicFieldsModelSerializer
+from shop.serializers.feedback import FeedbackOutputSerializer
+from shop.serializers.image import ImageOutputSerializer
+from shop.serializers.product_material import MaterialOutputSerializer
 
 
-class ProductOutputSerializer(serializers.ModelSerializer):
+class ProductOutputSerializer(DynamicFieldsModelSerializer):
     category = serializers.SerializerMethodField()
-    materials = ProductMaterialOutputSerializerForProduct(many=True)
+    materials = MaterialOutputSerializer(many=True, fields_to_remove=['product'])
+    images = ImageOutputSerializer(many=True)
+    feedback = FeedbackOutputSerializer(many=True, fields_to_remove=['product'])
 
     class Meta:
         model = Product
-        fields = ('category', 'name', 'price', 'description', 'size', 'weight', 'stock', 'materials')
+        fields = ('category', 'name', 'price', 'description', 'size', 'weight', 'stock', 'materials', 'images',
+                  'feedback')
 
     @staticmethod
     def get_category(obj):
         from shop.serializers.category import CategoryOutputSerializer
         return CategoryOutputSerializer(obj.category).data
-
-
-class ProductOutputSerializerForCategory(serializers.ModelSerializer):
-    class Meta:
-        model = Product
-        fields = ('name', 'price', 'description', 'size', 'weight', 'stock')

--- a/shop/serializers/product_material.py
+++ b/shop/serializers/product_material.py
@@ -1,21 +1,23 @@
 from rest_framework import serializers
 
 from shop.models import ProductMaterial
+from shop.serializers import DynamicFieldsModelSerializer
 
 
-class ProductMaterialOutputSerializer(serializers.ModelSerializer):
+class MaterialOutputSerializer(DynamicFieldsModelSerializer):
+    product = serializers.SerializerMethodField()
+
     class Meta:
         model = ProductMaterial
         fields = ('name', 'product')
 
+    @staticmethod
+    def get_product(obj):
+        from shop.serializers.product import ProductOutputSerializer
+        return ProductOutputSerializer(obj.product).data
 
-class ProductMaterialOutputSerializerForProduct(serializers.ModelSerializer):
-    class Meta:
-        model = ProductMaterial
-        fields = ('name', )
 
-
-class ProductMaterialInputSerializer(serializers.ModelSerializer):
+class MaterialInputSerializer(serializers.ModelSerializer):
     class Meta:
         model = ProductMaterial
         fields = ('name', 'product')

--- a/shop/tests/test_views/test_feedback.py
+++ b/shop/tests/test_views/test_feedback.py
@@ -8,7 +8,7 @@ from rest_framework import status
 
 from shop.exceptions import UnhandledValueError
 from shop.models import Feedback, Image
-from shop.serializers.feedback import FeedbackDetailSerializer, FeedbackListSerializer
+from shop.serializers.feedback import FeedbackOutputSerializer
 from shop.tests.conftest import Arg, ClientType, existent_pk, nonexistent_pk
 
 
@@ -60,7 +60,7 @@ class TestFeedbackViews:
         response = api_client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.data == FeedbackListSerializer(instance=feedback_list, many=True).data
+        assert response.data == FeedbackOutputSerializer(instance=feedback_list, many=True).data
 
     @pytest.mark.parametrize('client_type, feedback_product, title, content, images, status_code', [
         (ClientType.NOT_AUTH_CLIENT, None, None, None, None, status.HTTP_403_FORBIDDEN),
@@ -108,7 +108,7 @@ class TestFeedbackViews:
         response = api_client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.data == FeedbackDetailSerializer(instance=moderated_feedback).data
+        assert response.data == FeedbackOutputSerializer(instance=moderated_feedback).data
 
     @pytest.mark.parametrize(
         'client_type, feedback_product, title, content, images, status_code', [

--- a/shop/tests/test_views/test_image.py
+++ b/shop/tests/test_views/test_image.py
@@ -5,7 +5,7 @@ from rest_framework import status
 
 from shop.exceptions import UnhandledValueError
 from shop.models import Image, Order, get_image_models
-from shop.serializers.image import ImageDetailSerializer, ImageListSerializer
+from shop.serializers.image import ImageOutputSerializer
 from shop.tests.conftest import Arg, ClientType, existent_pk, nonexistent_pk
 
 
@@ -31,7 +31,7 @@ class TestImageViews:
         response = authenticated_api_client(is_admin=True).get(url)
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.data == ImageListSerializer(instance=image_list, many=True).data
+        assert response.data == ImageOutputSerializer(instance=image_list, many=True).data
 
     @pytest.mark.parametrize('client_type, image, content_type, object_id, status_code', [
         (ClientType.NOT_AUTH_CLIENT, None, None, None, status.HTTP_403_FORBIDDEN),
@@ -84,7 +84,7 @@ class TestImageViews:
         response = authenticated_api_client(is_admin=True).get(url)
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.data == ImageDetailSerializer(instance=image).data
+        assert response.data == ImageOutputSerializer(instance=image).data
 
     @pytest.mark.parametrize(
         'client_type, image_pk, status_code', [

--- a/shop/tests/test_views/test_product_material.py
+++ b/shop/tests/test_views/test_product_material.py
@@ -5,7 +5,7 @@ from rest_framework import status
 
 from shop.exceptions import UnhandledValueError
 from shop.models import ProductMaterial
-from shop.serializers.product_material import ProductMaterialOutputSerializer
+from shop.serializers.product_material import MaterialOutputSerializer
 from shop.tests.conftest import ClientType, existent_pk, nonexistent_pk
 
 
@@ -23,7 +23,7 @@ class TestProductMaterialViews:
         assert response.status_code == status_code
         if client_type == ClientType.ADMIN_CLIENT:
             material_list = ProductMaterial.objects.all()
-            assert response.data == ProductMaterialOutputSerializer(instance=material_list, many=True).data
+            assert response.data == MaterialOutputSerializer(instance=material_list, many=True).data
 
     @pytest.mark.parametrize('client_type, status_code', [
         (ClientType.NOT_AUTH_CLIENT, status.HTTP_403_FORBIDDEN),
@@ -70,7 +70,7 @@ class TestProductMaterialViews:
 
         assert response.status_code == status_code
         if client_type == ClientType.ADMIN_CLIENT:
-            assert response.data == ProductMaterialOutputSerializer(instance=material).data
+            assert response.data == MaterialOutputSerializer(instance=material).data
 
     @pytest.mark.parametrize(
         'client_type, material_pk, status_code', [

--- a/shop/views/address.py
+++ b/shop/views/address.py
@@ -5,7 +5,7 @@ from rest_framework.views import APIView
 
 from shop.controllers.address import AddressController
 from shop.permissions import check_permissions, is_owner_or_admin_factory
-from shop.serializers.address import AddressOutputSerializer, AddressInputSerializer
+from shop.serializers.address import AddressInputSerializer, AddressOutputSerializer
 
 
 class AddressView(APIView):

--- a/shop/views/feedback.py
+++ b/shop/views/feedback.py
@@ -4,8 +4,8 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from shop.controllers.feedback import FeedbackController
-from shop.permissions import is_owner_or_admin_factory, check_permissions
-from shop.serializers.feedback import FeedbackDetailSerializer, FeedbackInputSerializer, FeedbackListSerializer
+from shop.permissions import check_permissions, is_owner_or_admin_factory
+from shop.serializers.feedback import FeedbackInputSerializer, FeedbackOutputSerializer
 
 
 class FeedbackList(APIView):
@@ -14,7 +14,7 @@ class FeedbackList(APIView):
     @classmethod
     def get(cls, request):
         feedback = FeedbackController.get_feedback_list()
-        data = FeedbackListSerializer(instance=feedback, many=True).data
+        data = FeedbackOutputSerializer(instance=feedback, many=True).data
 
         return Response(data, status.HTTP_200_OK)
 
@@ -34,7 +34,7 @@ class FeedbackDetail(APIView):
     @classmethod
     def get(cls, request, pk):
         feedback = FeedbackController.get_feedback(pk)
-        data = FeedbackDetailSerializer(instance=feedback).data
+        data = FeedbackOutputSerializer(instance=feedback).data
 
         return Response(data, status.HTTP_200_OK)
 

--- a/shop/views/image.py
+++ b/shop/views/image.py
@@ -4,7 +4,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from shop.controllers.image import ImageController
-from shop.serializers.image import ImageDetailSerializer, ImageInputSerializer, ImageListSerializer
+from shop.serializers.image import ImageInputSerializer, ImageOutputSerializer
 
 
 class ImageView(APIView):
@@ -14,10 +14,10 @@ class ImageView(APIView):
     def get(cls, request, pk=None):
         if pk is None:
             images = ImageController.get_image_list()
-            data = ImageListSerializer(instance=images, many=True).data
+            data = ImageOutputSerializer(instance=images, many=True).data
         else:
             image = ImageController.get_image(pk)
-            data = ImageDetailSerializer(instance=image).data
+            data = ImageOutputSerializer(instance=image).data
 
         return Response(data, status.HTTP_200_OK)
 

--- a/shop/views/product_material.py
+++ b/shop/views/product_material.py
@@ -4,7 +4,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from shop.controllers.product_material import ProductMaterialController
-from shop.serializers.product_material import ProductMaterialInputSerializer, ProductMaterialOutputSerializer
+from shop.serializers.product_material import MaterialInputSerializer, MaterialOutputSerializer
 
 
 class ProductMaterialView(APIView):
@@ -14,16 +14,16 @@ class ProductMaterialView(APIView):
     def get(cls, request, pk=None):
         if pk is None:
             materials = ProductMaterialController.get_material_list()
-            data = ProductMaterialOutputSerializer(instance=materials, many=True).data
+            data = MaterialOutputSerializer(instance=materials, many=True).data
         else:
             material = ProductMaterialController.get_material(pk)
-            data = ProductMaterialOutputSerializer(instance=material).data
+            data = MaterialOutputSerializer(instance=material).data
 
         return Response(data, status.HTTP_200_OK)
 
     @classmethod
     def post(cls, request):
-        serializer = ProductMaterialInputSerializer(data=request.data)
+        serializer = MaterialInputSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         ProductMaterialController.create_material(**serializer.validated_data)
 
@@ -31,7 +31,7 @@ class ProductMaterialView(APIView):
 
     @classmethod
     def put(cls, request, pk):
-        serializer = ProductMaterialInputSerializer(data=request.data)
+        serializer = MaterialInputSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         ProductMaterialController.update_material(pk, **serializer.validated_data)
 


### PR DESCRIPTION
1. Add missing serializer relationships
1. Create DynamicFieldsModelSerializer to give descendants the ability to remove specific fields from them when they are initialized
1. Move detail and list serializers into one output serializer for image and feedback serializers
1. Rename ProductMaterialOutputSerializer to MaterialOutputSerializer for brevity (same for MaterialInputSerializer)
1. Category serializer now serializes parent and child categories at the same time
1. Remove RecursiveField as unnecessary